### PR TITLE
add spacing to readme

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -21,6 +21,7 @@ This example has been developed and tested using the Kubernetes Engine packaged 
 
 ## Setup Prometheus and Grafana
 1. `cd` into the *scripts* folder and run the setup script with `./setup.sh` - the process of configuring Prometheus and Grafana.
+
 **Note**: If you run into `Permission denied` error, try run this command: `chmod +x [the_file_name]` in the terminal and re-run `./setup.sh`.
 
 2. In your browser, go to `localhost:32000`, which will be the login page of grafana. Use `admin` as both username and password to login. You can change the password after login.
@@ -75,9 +76,9 @@ kubectl apply -f frontend.yml
 
 **Mac Users:** Alternative to running the above commands, `cd` into the *scripts* folder and run the `startKuber.sh` script.
 
-#
 
 2. `cd` into the `server` folder inside `chronos_npm_package`, then run `npm install` and `npm start`
+
 3. Check in Docker desktop if your containers have been created. You should see something similar to the following:
 
 <p align="center">
@@ -86,8 +87,9 @@ kubectl apply -f frontend.yml
 
 
 Your microservice health metrics can now be viewed at the given `CHRONOS_URI` or, preferrably, in the Electron.js desktop application.
-#
+
 ## Teardown the Cluster
+
 1. `cd` into the launch folder and run the following commands to stop the running services and deployments:
 ```
 kubectl delete -f clusterRole.yml


### PR DESCRIPTION
References issue #. Please review this @teammember1, @teammember2.

# Types of changes
- [ ]  Bugfix (change which fixes an issue)
- [ ]  New feature (change which adds functionality)
- [ ]  Refactor (change which changes the codebase without affecting its external behavior)
- [ ]  Non-breaking change (fix or feature that would cause existing functionality to work as expected)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
# Purpose
- Need to send either schema file or schema code to backend to generate new databases containing schema
- Generate and concat table and database list upon user instantiation of schema/database
- Enable modal interface for clear user input of schema
- Fix minor bugs causing lack of interaction with buttons/input fields
# Approach
- Removed the if else statement for changing databases within the query input ‘\c defaultDB’. At this time there is no way of changing databases in the application.
- Got rid of getConnectionString method on modal object and added that functionality into the changeDB method. No longer will have random console logged ‘undefined’ anymore.
- Created a getLists method on the modal object that queries the database twice. Once for the table list and second for the database list and returns them in an object of two arrays.
# Learning
- https://kb.objectrocket.com/postgresql/how-to-show-databases-in-postgresql-848#:~:text=The%20%5Cl%20command%20in%20psql,to%20achieve%20the%20same%20results.
- https://flaviocopes.com/postgres-how-to-list-tables-database/#:~:text=To%20list%20the%20tables%20in,SELECT%20table_name%20FROM%20information_schema.
# Screenshot(s)
![image](https://user-images.githubusercontent.com/9983876/104249836-10f3d000-5421-11eb-8b3e-a18646432d86.png)
